### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It is fully compatable with with the [cine.io Peer Android SDK][cineio-peer-andr
 ## Installation
 
 The easiest way to use the SDK is via [CocoaPods][cocoapods]. Create a new
-XCode project with a file named `Podfile` that contains the
+Xcode project with a file named `Podfile` that contains the
 following:
 
 ```ruby


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
